### PR TITLE
Fixes for julia 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ os:
   - osx
 julia:
   - 0.6
+  - 0.7
+  - 1.0
   - nightly
 notifications:
   email: false
@@ -27,9 +29,9 @@ git:
 
 ## uncomment the following lines to override the default test script
 #script:
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("ElasticArrays"); Pkg.test("ElasticArrays"; coverage=true)'
+#  - julia -e 'VERSION >= v"0.7-" && import Pkg; Pkg.clone(pwd()); Pkg.build("ElasticArrays"); Pkg.test("ElasticArrays"; coverage=true)'
 after_success:
   # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("ElasticArrays")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'VERSION >= v"0.7-" && import Pkg; cd(Pkg.dir("ElasticArrays")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("ElasticArrays")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'VERSION >= v"0.7-" && import Pkg; cd(Pkg.dir("ElasticArrays")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/src/elasticarray.jl
+++ b/src/elasticarray.jl
@@ -66,15 +66,18 @@ import Base.==
 
 Base.parent(A::ElasticArray) = A.data
 
-Base.size(A::ElasticArray) = (A.kernel_size..., div(length(linearindices(A.data)), A.kernel_length))
+Base.size(A::ElasticArray) = (A.kernel_size..., div(length(LinearIndices(A.data)), A.kernel_length))
 @propagate_inbounds Base.getindex(A::ElasticArray, i::Integer) = getindex(A.data, i)
 @propagate_inbounds Base.setindex!(A::ElasticArray, x, i::Integer) = setindex!(A.data, x, i)
 @inline Base.IndexStyle(A::ElasticArray) = IndexStyle(A.data)
 
 Base.length(A::ElasticArray) = length(A.data)
-Base._length(A::ElasticArray) = Base._length(A.data)
 
-Base.linearindices(A::ElasticArray) = linearindices(A.data)
+@static if VERSION < v"0.7"
+    Base._length(A::ElasticArray) = Base._length(A.data)
+end
+
+Compat.LinearIndices(A::ElasticArray) = LinearIndices(A.data)
 
 @static if VERSION < v"0.7.0-DEV.2791"
     Base.repremptyarray(io::IO, X::ElasticArray{T}) where {T} = print(io, "ElasticArray{$T}(", join(size(X),','), ')')
@@ -95,14 +98,14 @@ end
 
 
 function Base.append!(dest::ElasticArray, src::AbstractArray)
-    rem(length(linearindices(src)), dest.kernel_length) != 0 && throw(DimensionMismatch("Can't append, length of source array is incompatible"))
+    rem(length(LinearIndices(src)), dest.kernel_length) != 0 && throw(DimensionMismatch("Can't append, length of source array is incompatible"))
     append!(dest.data, src)
     dest
 end
 
 
 function Base.prepend!(dest::ElasticArray, src::AbstractArray)
-    rem(length(linearindices(src)), dest.kernel_length) != 0 && throw(DimensionMismatch("Can't prepend, length of source array is incompatible"))
+    rem(length(LinearIndices(src)), dest.kernel_length) != 0 && throw(DimensionMismatch("Can't prepend, length of source array is incompatible"))
     prepend!(dest.data, src)
     dest
 end

--- a/test/elasticarray.jl
+++ b/test/elasticarray.jl
@@ -4,7 +4,7 @@ using ElasticArrays
 using Compat
 using Compat.Test
 using Compat.Random
-using Compat: axes
+using Compat: axes, LinearIndices
 
 
 @testset "elasticarray" begin
@@ -17,10 +17,14 @@ using Compat: axes
     end
 
     function test_A(test_code)
-        @static if VERSION >= v"0.7.0-DEV.2552"
-            A = rand!(@test_deprecated(Array{Int}(test_dims...)), 0:99)
+        @static if VERSION >= v"1.0.0-"
+            A = rand!(Array{Int}(undef, test_dims...), 0:99)
         else
-            A = rand!(Array{Int}(test_dims...), 0:99)
+            @static if VERSION >= v"0.7.0-DEV.2552"
+                A = rand!(@test_deprecated(Array{Int}(test_dims...)), 0:99)
+            else
+                A = rand!(Array{Int}(test_dims...), 0:99)
+            end
         end
         test_code(A)
     end
@@ -67,9 +71,8 @@ using Compat: axes
 
         test_E() do E
             @test length(E) == prod(size(E))
-            @test Base._length(E) == prod(size(E))
             @test IndexStyle(E) == IndexLinear()
-            @test linearindices(E) == linearindices(parent(E))
+            @test LinearIndices(E) == LinearIndices(parent(E))
             @test eachindex(E) == eachindex(parent(E))
         end
     end


### PR DESCRIPTION
Note that `Base._length()` has been deprecated to `length()`.  I therefore removed the corresponding test, as it would have been redundant with the following line.