### PR TITLE
Add underlying array type to enable GPU use.

### DIFF
--- a/test/elasticarray.jl
+++ b/test/elasticarray.jl
@@ -225,7 +225,7 @@ using Random
             @test eltype(E) == eltype(A)
         end
 
-        @test typeof(@inferred similar(ElasticArray{Int}, (2,3,4))) == ElasticArray{Int,3,2}
+        @test typeof(@inferred similar(ElasticArray{Int}, (2,3,4))) == ElasticArray{Int,3,2,Vector{Int}}
         @test size(@inferred similar(ElasticArray{Int}, (2,3,4))) == (2,3,4)
     end
 


### PR DESCRIPTION
This PR adds the type of the underlying vector to the `ElasticArray` struct. This enables one to use a non-`Vector` type, for instance a `CuArray`, with the package. It also adds a constructor so that `Flux.@functor` works with ElasticArrays out-of-the-box. The arrays appear to work on GPU just fine, albeit with scalar getindex, which is slow but nonetheless functional.