### PR TITLE
Miscellaneous fixes/improvements

### DIFF
--- a/src/elasticarray.jl
+++ b/src/elasticarray.jl
@@ -112,31 +112,23 @@ function _split_resize_dims(A::ElasticArray, dims::NTuple{N,Integer}) where {N}
 end
 
 
-
-function Base.append!(dest::ElasticArray, src::AbstractArray)
-    rem(length(eachindex(src)), dest.kernel_length) != 0 && throw(DimensionMismatch("Can't append, length of source array is incompatible"))
-    append!(dest.data, src)
-    return dest
-end
-
 function Base.append!(dest::ElasticArray, iter)
-    for el in iter
-        append!(dest, el)
-    end
-    return dest
-end
-
-function Base.prepend!(dest::ElasticArray, src::AbstractArray)
-    rem(length(eachindex(src)), dest.kernel_length) != 0 && throw(DimensionMismatch("Can't prepend, length of source array is incompatible"))
-    prepend!(dest.data, src)
+    append!(dest.data, iter)
+    _check_size(dest)
     return dest
 end
 
 function Base.prepend!(dest::ElasticArray, iter)
-    for el in iter
-        prepend!(dest, el)
-    end
+    prepend!(dest.data, iter)
+    _check_size(dest)
     return dest
+end
+
+@inline function _check_size(A::ElasticArray)
+    if rem(length(eachindex(A.data)), A.kernel_length) != 0
+        throw(DimensionMismatch("Can't append, length of source array is incompatible"))
+    end
+    nothing
 end
 
 
@@ -186,3 +178,5 @@ end
 @inline Base.unsafe_convert(::Type{Ptr{T}}, A::ElasticArray{T}) where T = Base.unsafe_convert(Ptr{T}, A.data)
 
 @inline Base.pointer(A::ElasticArray, i::Integer) = pointer(A.data, i)
+
+

--- a/src/elasticarray.jl
+++ b/src/elasticarray.jl
@@ -68,7 +68,7 @@ Base.size(A::ElasticArray) = (A.kernel_size..., div(length(eachindex(A.data)), A
 
 @propagate_inbounds Base.setindex!(A::ElasticArray, x, i::Integer) = setindex!(A.data, x, i)
 
-@inline Base.IndexStyle(A::ElasticArray) = IndexStyle(A.data)
+Base.IndexStyle(::Type{<:ElasticArray}) = IndexLinear()
 
 Base.length(A::ElasticArray) = length(A.data)
 

--- a/src/elasticarray.jl
+++ b/src/elasticarray.jl
@@ -57,11 +57,9 @@ ElasticArray(A::AbstractArray{T,N}) where {T,N} = copyto!(ElasticArray{T,N}(unde
 Base.convert(::Type{T}, A::AbstractArray) where {T<:ElasticArray} = A isa T ? A : T(A)
 
 
-
-
-import Base.==
-(==)(A::ElasticArray, B::ElasticArray) =
+function Base.:(==)(A::ElasticArray, B::ElasticArray)
     ndims(A) == ndims(B) && A.kernel_size == B.kernel_size && A.data == B.data
+end
 
 
 Base.parent(A::ElasticArray) = A.data

--- a/src/elasticarray.jl
+++ b/src/elasticarray.jl
@@ -76,25 +76,41 @@ end
 Base.IndexStyle(::Type{<:ElasticArray}) = IndexLinear()
 
 
+
 @inline Base.resize!(A::ElasticArray{T,N}, dims::Vararg{Integer,N}) where {T,N} = resize!(A, dims)
+
 @inline function Base.resize!(A::ElasticArray{T,N}, dims::NTuple{N,Integer}) where {T,N}
-    kernel_size, size_lastdim = _split_resize_dims(A, dims)
+    _, size_lastdim = _split_resize_dims(A, dims)
     resize!(A.data, A.kernel_length.divisor * size_lastdim)
     return A
 end
 
+@inline function Base.resize!(A::ElasticArray, size_lastdim::Integer)
+    resize!(A.data, A.kernel_length.divisor * size_lastdim)
+    return A
+end
+
+
 @inline Base.sizehint!(A::ElasticArray{T,N}, dims::Vararg{Integer,N}) where {T,N} = sizehint!(A, dims)
+
 @inline function Base.sizehint!(A::ElasticArray{T,N}, dims::NTuple{N,Integer}) where {T,N}
-    kernel_size, size_lastdim = _split_resize_dims(A, dims)
+    _, size_lastdim = _split_resize_dims(A, dims)
     sizehint!(A.data, A.kernel_length.divisor * size_lastdim)
     return A
 end
+
+@inline function Base.sizehint!(A::ElasticArray, size_lastdim::Integer)
+    sizehint!(A.data, A.kernel_length.divisor * size_lastdim)
+    return A
+end
+
 
 function _split_resize_dims(A::ElasticArray, dims::NTuple{N,Integer}) where {N}
     kernel_size, size_lastdim = _split_dims(dims)
     kernel_size != A.kernel_size && throw(ArgumentError("Can only resize last dimension of an ElasticArray"))
     return kernel_size, size_lastdim
 end
+
 
 
 function Base.append!(dest::ElasticArray, src::AbstractArray)

--- a/src/elasticarray.jl
+++ b/src/elasticarray.jl
@@ -103,9 +103,23 @@ function Base.append!(dest::ElasticArray, src::AbstractArray)
     return dest
 end
 
+function Base.append!(dest::ElasticArray, iter)
+    for el in iter
+        append!(dest, el)
+    end
+    return dest
+end
+
 function Base.prepend!(dest::ElasticArray, src::AbstractArray)
     rem(length(eachindex(src)), dest.kernel_length) != 0 && throw(DimensionMismatch("Can't prepend, length of source array is incompatible"))
     prepend!(dest.data, src)
+    return dest
+end
+
+function Base.prepend!(dest::ElasticArray, iter)
+    for el in iter
+        prepend!(dest, el)
+    end
     return dest
 end
 

--- a/src/elasticarray.jl
+++ b/src/elasticarray.jl
@@ -76,13 +76,15 @@ end
 Base.IndexStyle(::Type{<:ElasticArray}) = IndexLinear()
 
 
-@inline function Base.resize!(A::ElasticArray{T,N}, dims::Vararg{Integer,N}) where {T,N}
+@inline Base.resize!(A::ElasticArray{T,N}, dims::Vararg{Integer,N}) where {T,N} = resize!(A, dims)
+@inline function Base.resize!(A::ElasticArray{T,N}, dims::NTuple{N,Integer}) where {T,N}
     kernel_size, size_lastdim = _split_resize_dims(A, dims)
     resize!(A.data, A.kernel_length.divisor * size_lastdim)
     return A
 end
 
-@inline function Base.sizehint!(A::ElasticArray{T,N}, dims::Vararg{Integer,N}) where {T,N}
+@inline Base.sizehint!(A::ElasticArray{T,N}, dims::Vararg{Integer,N}) where {T,N} = sizehint!(A, dims)
+@inline function Base.sizehint!(A::ElasticArray{T,N}, dims::NTuple{N,Integer}) where {T,N}
     kernel_size, size_lastdim = _split_resize_dims(A, dims)
     sizehint!(A.data, A.kernel_length.divisor * size_lastdim)
     return A

--- a/src/elasticarray.jl
+++ b/src/elasticarray.jl
@@ -60,14 +60,14 @@ Base.convert(::Type{T}, A::AbstractArray) where {T<:ElasticArray} = A isa T ? A 
 Base.similar(::Type{ElasticArray{T}}, dims::Dims{N}) where {T,N} = ElasticArray{T}(undef, dims...)
 
 
-function Base.:(==)(A::ElasticArray, B::ElasticArray)
+@inline function Base.:(==)(A::ElasticArray, B::ElasticArray)
     return ndims(A) == ndims(B) && A.kernel_size == B.kernel_size && A.data == B.data
 end
 
 
-Base.size(A::ElasticArray) = (A.kernel_size..., div(length(eachindex(A.data)), A.kernel_length))
+@inline Base.size(A::ElasticArray) = (A.kernel_size..., div(length(eachindex(A.data)), A.kernel_length))
 
-Base.length(A::ElasticArray) = length(A.data)
+@inline Base.length(A::ElasticArray) = length(A.data)
 
 @propagate_inbounds Base.getindex(A::ElasticArray, i::Int) = getindex(A.data, i)
 
@@ -111,7 +111,7 @@ end
 @inline function Base.copyto!(
     dest::ElasticArray,
     doffs::Integer,
-    src::AbsArr,
+    src::AbstractArray,
     soffs::Integer,
     N::Integer,
 )
@@ -119,7 +119,7 @@ end
     return dest
 end
 @inline function Base.copyto!(
-    dest::AbsArr,
+    dest::AbstractArray,
     doffs::Integer,
     src::ElasticArray,
     soffs::Integer,
@@ -128,8 +128,8 @@ end
     copyto!(dest, doffs, src.data, soffs, N)
 end
 
-@inline Base.copyto!(dest::ElasticArray, src::AbsArr) = (copyto!(dest.data, src); dest)
-@inline Base.copyto!(dest::AbsArr, src::ElasticArray) = copyto!(dest, src.data)
+@inline Base.copyto!(dest::ElasticArray, src::AbstractArray) = (copyto!(dest.data, src); dest)
+@inline Base.copyto!(dest::AbstractArray, src::ElasticArray) = copyto!(dest, src.data)
 
 @inline function Base.copyto!(
     dest::ElasticArray,
@@ -147,10 +147,10 @@ end
 end
 
 
-Base.dataids(A::ElasticArray) = Base.dataids(A.data)
+@inline Base.dataids(A::ElasticArray) = Base.dataids(A.data)
 
-Base.parent(A::ElasticArray) = A.data
+@inline Base.parent(A::ElasticArray) = A.data
 
-Base.unsafe_convert(::Type{Ptr{T}}, A::ElasticArray{T}) where T = Base.unsafe_convert(Ptr{T}, A.data)
+@inline Base.unsafe_convert(::Type{Ptr{T}}, A::ElasticArray{T}) where T = Base.unsafe_convert(Ptr{T}, A.data)
 
-Base.pointer(A::ElasticArray, i::Integer) = pointer(A.data, i)
+@inline Base.pointer(A::ElasticArray, i::Integer) = pointer(A.data, i)

--- a/src/elasticarray.jl
+++ b/src/elasticarray.jl
@@ -101,7 +101,6 @@ function Base.append!(dest::ElasticArray, src::AbstractArray)
     return dest
 end
 
-
 function Base.prepend!(dest::ElasticArray, src::AbstractArray)
     rem(length(eachindex(src)), dest.kernel_length) != 0 && throw(DimensionMismatch("Can't prepend, length of source array is incompatible"))
     prepend!(dest.data, src)
@@ -109,20 +108,43 @@ function Base.prepend!(dest::ElasticArray, src::AbstractArray)
 end
 
 
-@inline function _copyto_impl!(dest::ElasticArray, args...)
-    copyto!(dest.data, args...)
-    dest
+@inline function Base.copyto!(
+    dest::ElasticArray,
+    doffs::Integer,
+    src::AbsArr,
+    soffs::Integer,
+    N::Integer,
+)
+    copyto!(dest.data, doffs, src, soffs, N)
+    return dest
+end
+@inline function Base.copyto!(
+    dest::AbsArr,
+    doffs::Integer,
+    src::ElasticArray,
+    soffs::Integer,
+    N::Integer,
+)
+    copyto!(dest, doffs, src.data, soffs, N)
 end
 
-@inline Base.copyto!(dest::ElasticArray, doffs::Integer, src::AbstractArray, args::Integer...) = _copyto_impl!(dest, doffs, src, args...)
-@inline Base.copyto!(dest::ElasticArray, src::AbstractArray) = _copyto_impl!(dest, src)
+@inline Base.copyto!(dest::ElasticArray, src::AbsArr) = (copyto!(dest.data, src); dest)
+@inline Base.copyto!(dest::AbsArr, src::ElasticArray) = copyto!(dest, src.data)
 
-@inline Base.copyto!(dest::ElasticArray, doffs::Integer, src::ElasticArray, args::Integer...) = _copyto_impl!(dest, doffs, src, args...)
-@inline Base.copyto!(dest::ElasticArray, src::ElasticArray) = _copyto_impl!(dest, src)
-
-@inline Base.copyto!(dest::AbstractArray, doffs::Integer, src::ElasticArray, args::Integer...) = copyto!(dest, doffs, src.data, args...)
-@inline Base.copyto!(dest::AbstractArray, src::ElasticArray) = copyto!(dest, src.data)
-
+@inline function Base.copyto!(
+    dest::ElasticArray,
+    doffs::Integer,
+    src::ElasticArray,
+    soffs::Integer,
+    N::Integer,
+)
+    copyto!(dest.data, doffs, src.data, soffs, N)
+    return dest
+end
+@inline function Base.copyto!(dest::ElasticArray, src::ElasticArray)
+    copyto!(dest.data, src.data)
+    return dest
+end
 
 
 Base.dataids(A::ElasticArray) = Base.dataids(A.data)

--- a/src/elasticarray.jl
+++ b/src/elasticarray.jl
@@ -85,7 +85,7 @@ Base.IndexStyle(::Type{<:ElasticArray}) = IndexLinear()
     return A
 end
 
-@inline function Base.resize!(A::ElasticArray, size_lastdim::Integer)
+@inline function resize_lastdim!(A::ElasticArray, size_lastdim::Integer)
     resize!(A.data, A.kernel_length.divisor * size_lastdim)
     return A
 end
@@ -99,7 +99,7 @@ end
     return A
 end
 
-@inline function Base.sizehint!(A::ElasticArray, size_lastdim::Integer)
+@inline function sizehint_lastdim!(A::ElasticArray, size_lastdim::Integer)
     sizehint!(A.data, A.kernel_length.divisor * size_lastdim)
     return A
 end
@@ -178,5 +178,3 @@ end
 @inline Base.unsafe_convert(::Type{Ptr{T}}, A::ElasticArray{T}) where T = Base.unsafe_convert(Ptr{T}, A.data)
 
 @inline Base.pointer(A::ElasticArray, i::Integer) = pointer(A.data, i)
-
-

--- a/src/elasticarray.jl
+++ b/src/elasticarray.jl
@@ -62,16 +62,16 @@ function Base.:(==)(A::ElasticArray, B::ElasticArray)
 end
 
 
-Base.parent(A::ElasticArray) = A.data
-
 Base.size(A::ElasticArray) = (A.kernel_size..., div(length(eachindex(A.data)), A.kernel_length))
+
 @propagate_inbounds Base.getindex(A::ElasticArray, i::Integer) = getindex(A.data, i)
+
 @propagate_inbounds Base.setindex!(A::ElasticArray, x, i::Integer) = setindex!(A.data, x, i)
+
 @inline Base.IndexStyle(A::ElasticArray) = IndexStyle(A.data)
 
 Base.length(A::ElasticArray) = length(A.data)
 
-Base.dataids(A::ElasticArray) = Base.dataids(A.data)
 
 
 @inline function Base.resize!(A::ElasticArray{T,N}, dims::Vararg{Integer,N}) where {T,N}
@@ -124,6 +124,10 @@ end
 
 Base.similar(::Type{ElasticArray{T}}, dims::Dims{N}) where {T,N} = ElasticArray{T}(undef, dims...)
 
+
+Base.dataids(A::ElasticArray) = Base.dataids(A.data)
+
+Base.parent(A::ElasticArray) = A.data
 
 Base.unsafe_convert(::Type{Ptr{T}}, A::ElasticArray{T}) where T = Base.unsafe_convert(Ptr{T}, A.data)
 

--- a/src/elasticarray.jl
+++ b/src/elasticarray.jl
@@ -64,9 +64,9 @@ end
 
 Base.size(A::ElasticArray) = (A.kernel_size..., div(length(eachindex(A.data)), A.kernel_length))
 
-@propagate_inbounds Base.getindex(A::ElasticArray, i::Integer) = getindex(A.data, i)
+@propagate_inbounds Base.getindex(A::ElasticArray, i::Int) = getindex(A.data, i)
 
-@propagate_inbounds Base.setindex!(A::ElasticArray, x, i::Integer) = setindex!(A.data, x, i)
+@propagate_inbounds Base.setindex!(A::ElasticArray, x, i::Int) = setindex!(A.data, x, i)
 
 Base.IndexStyle(::Type{<:ElasticArray}) = IndexLinear()
 

--- a/test/elasticarray.jl
+++ b/test/elasticarray.jl
@@ -289,6 +289,26 @@ using Random
             @test size(E) == (dims..., length(V))
             @test test_comp(E, V)
         end
+
+        test_E_V() do E, V
+            dims = Base.front(size(E))
+            for i in 1:4
+                push!(V, rand(dims...))
+            end
+            @inferred append!(E, (el for el in V))
+            @test size(E) == (dims..., length(V))
+            @test test_comp(E, V)
+        end
+
+        test_E_V() do E, V
+            dims = Base.front(size(E))
+            for i in 1:4
+                pushfirst!(V, rand(dims...))
+            end
+            @inferred prepend!(E, (el for el in reverse(V)))
+            @test size(E) == (dims..., length(V))
+            @test test_comp(E, V)
+        end
     end
 
 

--- a/test/elasticarray.jl
+++ b/test/elasticarray.jl
@@ -265,8 +265,8 @@ using Random
                 A = Array(deepcopy(E))
                 new_size = (Base.front(size(E))..., size(E, ndims(E)) + delta)
                 cmp_idxs = (Base.front(axes(E))..., 1:(last(size(E)) + min(0, delta)))
-                @test E === @inferred sizehint!(E, size(E, ndims(E)) + delta)
-                @test E === @inferred resize!(E, size(E, ndims(E)) + delta)
+                @test E === @inferred ElasticArrays.sizehint_lastdim!(E, size(E, ndims(E)) + delta)
+                @test E === @inferred ElasticArrays.resize_lastdim!(E, size(E, ndims(E)) + delta)
                 @test size(E) == new_size
                 @test E[cmp_idxs...] == A[cmp_idxs...]
             end

--- a/test/elasticarray.jl
+++ b/test/elasticarray.jl
@@ -258,6 +258,23 @@ using Random
         resize_test(0)
         resize_test(2)
         resize_test(-2)
+
+
+        function resize_lastdim_test(delta::Integer)
+            test_E() do E
+                A = Array(deepcopy(E))
+                new_size = (Base.front(size(E))..., size(E, ndims(E)) + delta)
+                cmp_idxs = (Base.front(axes(E))..., 1:(last(size(E)) + min(0, delta)))
+                @test E === @inferred sizehint!(E, size(E, ndims(E)) + delta)
+                @test E === @inferred resize!(E, size(E, ndims(E)) + delta)
+                @test size(E) == new_size
+                @test E[cmp_idxs...] == A[cmp_idxs...]
+            end
+        end
+
+        resize_lastdim_test(0)
+        resize_lastdim_test(2)
+        resize_lastdim_test(-2)
     end
 
 

--- a/test/elasticarray.jl
+++ b/test/elasticarray.jl
@@ -307,24 +307,22 @@ using Random
             @test test_comp(E, V)
         end
 
-        test_E_V() do E, V
-            dims = Base.front(size(E))
-            for i in 1:4
-                push!(V, rand(dims...))
-            end
+        test_E() do E
+            kernel_size = Base.front(size(E))
+            kernel_length = last(size(E))
+            V = rand(Int, prod(kernel_size))
             @inferred append!(E, (el for el in V))
-            @test size(E) == (dims..., length(V))
-            @test test_comp(E, V)
+            @test size(E) == (kernel_size..., kernel_length + 1)
+            @test vec(E[:, :, kernel_length + 1]) == V
         end
 
-        test_E_V() do E, V
-            dims = Base.front(size(E))
-            for i in 1:4
-                pushfirst!(V, rand(dims...))
-            end
-            @inferred prepend!(E, (el for el in reverse(V)))
-            @test size(E) == (dims..., length(V))
-            @test test_comp(E, V)
+        test_E() do E
+            kernel_size = Base.front(size(E))
+            kernel_length = last(size(E))
+            V = rand(Int, prod(kernel_size))
+            @inferred prepend!(E, (el for el in V))
+            @test size(E) == (kernel_size..., kernel_length + 1)
+            @test vec(E[:, :, 1]) == V
         end
     end
 


### PR DESCRIPTION
As promised @oschulz, here's the PR! Everything should be non-breaking (I didn't break any tests at least). The only "questionable" change is 2a562cf which adds `sizehint!`/`resize!` where only the size in the last dimension is specified. Given that this is the only resizeable dimension it seems useful, but perhaps it would make more sense call them something different e.g. `sizehintlastdim!`/`resizelastdim`?