### PR TITLE
Broadcasting + better CuArrays support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "fdbdab4c-e67f-52f5-8c3f-e7b388dad3d4"
 version = "1.1.0"
 
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 
 [compat]
 julia = "1"

--- a/test/elasticarray.jl
+++ b/test/elasticarray.jl
@@ -67,7 +67,7 @@ using Random
             for i in eachindex(E, A)
                 E[i] = A[i]
             end
-            @test parent(E) == A[:]
+            @test parent(E) == A
             @test all(i -> E[i] == A[i], eachindex(E, A))
             @test all(i -> E[i] == A[i], CartesianIndices(size(A)))
         end
@@ -337,20 +337,21 @@ using Random
         A2 = Array(E2)
         A3 = Array(E3)
 
-        @test @inferred(2 * E1) isa Array{T,2}
+        @test @inferred(2 * E1) isa ElasticArray{T,2}
         @test 2 * E1 == 2 * A1
 
-        @test @inferred(E1 .+ 2) isa Array{T,2}
+        @test @inferred(E1 .+ 2) isa ElasticArray{T,2}
         @test E1 .+ 2 == A1 .+ 2
 
-        @test @inferred(E1 + E2) isa Array{T,2}
+        @test @inferred(E1 + E2) isa ElasticArray{T,2}
         @test E1 + E2 == A1 + A2
 
-        @test @inferred(E1 * E2) isa Array{T,2}
+        @test @inferred(E1 * E2) isa ElasticArray{T,2}
         @test E1 * E2 == A1 * A2
         @test E1 * E3 == A1 * A3
 
         @test E1^3 == A1^3
         @test inv(E1) == inv(A1)
+        @test inv(E1) isa ElasticArray{T,2}
     end
 end


### PR DESCRIPTION
1. Defines `Base.similar(A::ElasticArray, ::Type{T}, dims::Dims{N})` to return an ElasticArray.
2. Changes broadcasting to return an `ElasticArray`
3. Removes `Base.similar(::Type{ElasticArray{T}}, dims::Dims{N})`; the definition for `AbstractArray` in `Base` is sufficient.
4. Removes `parent(A::ElasticArray)`. Several functions in `LinearAlgebra` depend on `size(A) == size(parent)`. Given that `ElasticArray <: DenseArray` and we define `Base.pointer` this doesn't affect the ability to hit `BLAS`. Not sure what the other ramifications would be. The other alternative that works but feels wrong is `parent(A::ElasticArray) = reshape(A.data, size(A))` but that seems worse?
5. Adds `Adapt.adapt_structure(to, A::ElasticArray)` so the `CuArrays.cu(A::ElasticArray)` returns an `ElasticArray` wrapping a `CuArray`.

For `A::ElasticArray`, `A * A`, `2 * A`, and `inv(A)` now return an `ElasticArray`. The goal is for matrix operations to always return an `ElasticArray`, but without more test coverage I'm no sure if I'm missing something.

This depends on the changes in #20 so we can wait until that's merged. I also need to add a test for `adapt_structure`. I still hit scalar indexing with CuArrays, so need to figure that out as well.