### PR TITLE
Implement sizeof()

### DIFF
--- a/src/elasticarray.jl
+++ b/src/elasticarray.jl
@@ -83,6 +83,8 @@ end
 
 @inline Base.length(A::ElasticArray) = length(A.data)
 
+@inline Base.sizeof(A::ElasticArray) = sizeof(A.data)
+
 @propagate_inbounds Base.getindex(A::ElasticArray, i::Int) = getindex(A.data, i)
 
 @propagate_inbounds Base.setindex!(A::ElasticArray, x, i::Int) = setindex!(A.data, x, i)

--- a/test/elasticarray.jl
+++ b/test/elasticarray.jl
@@ -58,6 +58,7 @@ using Random
             @test length(E) == prod(size(E))
             @test IndexStyle(E) == IndexLinear()
             @test eachindex(E) == eachindex(parent(E))
+            @test sizeof(E) == sizeof(E.data)
         end
     end
 


### PR DESCRIPTION
This makes the behavior consistent with other array types.

I filed #24 while working on the test for this...