### PR TITLE
add deleteat! method

### DIFF
--- a/src/elasticarray.jl
+++ b/src/elasticarray.jl
@@ -118,7 +118,7 @@ end
 
 function Base.deleteat!(A::ElasticArray{T,N}, idxs::NTuple{N,Union{Tuple{},Int,Vector{Int},UnitRange{Int}}}) where {T,N}
     d = ndims(A)
-    prod(isempty.(first(idxs, length(idxs) - 1))) || throw(ArgumentError("Can only delete elements in the last dimension of A"))
+    prod(isempty.(idxs[1:end-1])) || throw(ArgumentError("Can only delete elements in the last dimension of A"))
     issubset(last(idxs), axes(A, d)) || throw(BoundsError(A, (ntuple(_->:,d-1)..., last(idxs))))
     keep = setdiff(axes(A, d), last(idxs))
     copyto!(A, selectdim(A, d, keep))

--- a/src/elasticarray.jl
+++ b/src/elasticarray.jl
@@ -116,6 +116,15 @@ end
     return A
 end
 
+function Base.deleteat!(A::ElasticArray{T,N}, idxs::Vararg{Union{Tuple{},Int,Vector{Int},UnitRange{Int}},N}) where {T,N}
+    d = ndims(A)
+    prod(isempty.(first(idxs, length(idxs) - 1))) || throw(ArgumentError("Can only delete elements in the last dimension of A"))
+    keep = setdiff(axes(A, d), last(idxs))
+    copyto!(A, selectdim(A, d, keep))
+    resize_lastdim!(A, length(keep))
+    return A
+end
+
 
 @inline Base.sizehint!(A::ElasticArray{T,N}, dims::Vararg{Integer,N}) where {T,N} = sizehint!(A, dims)
 

--- a/src/elasticarray.jl
+++ b/src/elasticarray.jl
@@ -116,13 +116,18 @@ end
     return A
 end
 
-function Base.deleteat!(A::ElasticArray{T,N}, idxs::Vararg{Union{Tuple{},Int,Vector{Int},UnitRange{Int}},N}) where {T,N}
+function Base.deleteat!(A::ElasticArray{T,N}, idxs::NTuple{N,Union{Tuple{},Int,Vector{Int},UnitRange{Int}}}) where {T,N}
     d = ndims(A)
     prod(isempty.(first(idxs, length(idxs) - 1))) || throw(ArgumentError("Can only delete elements in the last dimension of A"))
+    issubset(last(idxs), axes(A, d)) || throw(BoundsError(A, (ntuple(_->:,d-1)..., last(idxs))))
     keep = setdiff(axes(A, d), last(idxs))
     copyto!(A, selectdim(A, d, keep))
     resize_lastdim!(A, length(keep))
     return A
+end
+
+function Base.deleteat!(A::ElasticArray{T,N}, idxs::Vararg{Union{Tuple{},Int,Vector{Int},UnitRange{Int}},N}) where {T,N}
+    deleteat!(A, idxs)
 end
 
 

--- a/test/elasticarray.jl
+++ b/test/elasticarray.jl
@@ -296,6 +296,26 @@ using Random, LinearAlgebra
     end
 
 
+    @testset "deleteat!" begin
+
+        function deleteat_test()
+            test_E() do E
+
+                b = deepcopy(E)
+                n = ndims(E)
+                s = size(E,n)
+
+                @test_throws ArgumentError deleteat!(E, ntuple(_ -> 1, ndims(E)))
+                @test_throws MethodError deleteat!(E, ntuple(_ -> (), ndims(E) - 1))
+                @test_throws BoundsError deleteat!(E, ntuple(i -> i == n ? s + 1 : (), n))
+                @test E == deleteat!(E, ntuple(_ -> (), n))
+                @test selectdim(E, n, 2:s) == deleteat!(b, ntuple(i -> i == n ? 1 : (), n))
+            end
+        end
+
+        deleteat_test()
+    end 
+
     @testset "append! and prepend!" begin
        test_A() do A
             E = @inferred convert(ElasticArray{Float64}, A)

--- a/test/elasticarray.jl
+++ b/test/elasticarray.jl
@@ -298,22 +298,18 @@ using Random, LinearAlgebra
 
     @testset "deleteat!" begin
 
-        function deleteat_test()
-            test_E() do E
+        test_E() do E
+            b = deepcopy(E)
+            n = ndims(E)
+            s = size(E,n)
 
-                b = deepcopy(E)
-                n = ndims(E)
-                s = size(E,n)
-
-                @test_throws ArgumentError deleteat!(E, ntuple(_ -> 1, ndims(E)))
-                @test_throws MethodError deleteat!(E, ntuple(_ -> (), ndims(E) - 1))
-                @test_throws BoundsError deleteat!(E, ntuple(i -> i == n ? s + 1 : (), n))
-                @test E == deleteat!(E, ntuple(_ -> (), n))
-                @test selectdim(E, n, 2:s) == deleteat!(b, ntuple(i -> i == n ? 1 : (), n))
-            end
+            @test_throws ArgumentError deleteat!(E, ntuple(_ -> 1, ndims(E)))
+            @test_throws MethodError deleteat!(E, ntuple(_ -> (), ndims(E) - 1))
+            @test_throws BoundsError deleteat!(E, ntuple(i -> i == n ? s + 1 : (), n))
+            @test E == @inferred deleteat!(E, ntuple(_ -> (), n))
+            @test selectdim(E, n, 2:s) == @inferred deleteat!(b, ntuple(i -> i == n ? 1 : (), n))
         end
 
-        deleteat_test()
     end 
 
     @testset "append! and prepend!" begin


### PR DESCRIPTION
As discussed in #55. I kept the `deleteat!(A,(),i)` API.

The following are supported
```julia
a = ElasticArray(rand(7, 7, 7))
deleteat!(a, (), (), ())
deleteat!(a, (), (), 6)
deleteat!(a, (), (), [1, 5])
deleteat!(a, (), (), 3:4)
```
And this errors

```julia
deleteat!(a, 1:2, (), 1:2)
# ERROR: ArgumentError: Can only delete elements in the last dimension of A
```